### PR TITLE
Parametrize label as flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ npx octoherd-script-good-pr \
 | ---------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--octoherd-token`, `-T`     | string           | A personal access token ([create](https://github.com/settings/tokens/new?scopes=repo)). Script will create one if option is not set                                                                                                         |
 | `--octoherd-repos`, `-R`     | array of strings | One or multiple space-separated repositories in the form of `repo-owner/repo-name`. `repo-owner/*` will find all repositories for one owner. `*` will find all repositories the user has access to. Will prompt for repositories if not set |
-| `--octoherd-bypass-confirms` | boolean          | Bypass prompts to confirm mutating requests                                                                                                                                                                                                 |
+| `--octoherd-bypass-confirms` | boolean          | Bypass prompts to confirm mutating requests |
+| `--label` | string          | Label to apply to issues/pull-requests (default: `needs info`)                                                                                                                                                                                                 |
 
 ## Contributing
 

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
  * @param {import('@octoherd/cli').Repository} repository
  * @param { {label?: string} } options Custom user options passed to the CLI
  */
-export async function script(octokit, repository) {
+export async function script(octokit, repository, options) {
   const [repoOwner, repoName] = repository.full_name.split("/");
   const label = options.label || "needs info";
 

--- a/script.js
+++ b/script.js
@@ -5,9 +5,11 @@
  *
  * @param {import('@octoherd/cli').Octokit} octokit
  * @param {import('@octoherd/cli').Repository} repository
+ * @param { {label?: string} } options Custom user options passed to the CLI
  */
 export async function script(octokit, repository) {
   const [repoOwner, repoName] = repository.full_name.split("/");
+  const label = options.label || "needs info";
 
   const issues = await octokit.request('GET /repos/{owner}/{repo}/issues', {
     owner: repoOwner,
@@ -27,7 +29,7 @@ export async function script(octokit, repository) {
           owner: repoOwner,
           repo: repoName,
           issue_number: issues.data[i].number,
-          labels: ["needs info"] // TODO: make this label an argument
+          labels: [label]
         })
       }
     }


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- Add `--label` flag to script
- If not defined, it defaults to `needs info` label

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To give the option to the user to apply a different label than the default one
Fix #4 

## 📊 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run it in local and applied [here](https://github.com/oscard0m/sandbox/issues/44)
