### PR TITLE
fix: Loop only checked one issue at a time

### DIFF
--- a/script.js
+++ b/script.js
@@ -19,7 +19,7 @@ export async function script(octokit, repository, options) {
 
   try {
     for (let i = 0; i < issues.length; i++) {
-      const {body} = issues[0];
+      const {body} = issues[i];
 
       const todoExists = body.includes(forbiddenText);
 


### PR DESCRIPTION
In a stream yesterday with @blackgirlbytes we spent time triaging the gitignore repo. Turns out this script had been iterating over only 1 issue multiple times. 

This fix will make this script work as expected.  