### PR TITLE
fix: correct test status check re-triggering on main branch push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,11 @@
 name: Test
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
 
 jobs:
   test_matrix:


### PR DESCRIPTION
having "test" status check run on main push would make the release have to add it as a dependency, however forcing the pull request to pass that check makes it redundant to duplicate on push