### PR TITLE
fix: make release work with alternative status checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,18 @@ on:
       - main
 
 jobs:
+  test:
+    name: "Test matrix"
+    uses: bdougie/octoherd-script-validate-contribution/.github/workflows/test.yml@main
+
   release:
     environment:
       name: production
       url: https://github.com/${{ github.repository }}/releases/tag/${{ steps.semantic-release.outputs.release-tag }}
     name: Semantic release
     runs-on: ubuntu-latest
+    needs:
+      - test
     steps:
       - name: "☁️ checkout repository"
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,33 +6,33 @@ on:
       - edited
       - synchronize
       - reopened
+  workflow_call:
 
 jobs:
   test_matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: ["12", "14"]
+        node_version: [12, 14, 16, 17]
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js ${{ matrix.node_version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
+
+      - uses: bahmutov/npm-install@v1
+
       - run: npm test
 
-  # The "test" step can be required in branch protection and does not
-  # change each time the test matrix changes.
+  # the "test" step can NOT be required in branch protection if we
+  # are running semantic-release however it can be reused with a
+  # workflow_call.
   test:
     runs-on: ubuntu-latest
     needs: test_matrix
     steps:
-      - run: echo ok
+      - run: |
+          echo ok


### PR DESCRIPTION
Basically no need for anything, but admins need to not push stuff that doesn't work 🍕 

<img width="585" alt="Screenshot 2021-12-10 at 23 12 22" src="https://user-images.githubusercontent.com/237133/145641922-cfb41503-f070-42bd-962c-3501be59458b.png">

Do you feel like this too?

![](https://media.giphy.com/media/lnySV5m8IHhrx5M0e0/giphy.gif)